### PR TITLE
chore: switch typo theme from submodule to hugo module

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,10 +6,15 @@
 	"image": "mcr.microsoft.com/devcontainers/base:bookworm",
 	"features": {
 		"ghcr.io/devcontainers/features/hugo:1": {
-			"extended": true,
 			"version": "latest"
 		},
-		"ghcr.io/devcontainers/features/github-cli:1": {}
+		"ghcr.io/devcontainers/features/github-cli:1": {
+			"installDirectlyFromGitHubRelease": true,
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/go:1": {
+			"version": "latest"
+		}
 	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: weekly
 
-  - package-ecosystem: "gitsubmodule"
+  - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "themes/typo"]
-	path = themes/typo
-	url = https://github.com/tomfran/typo.git

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/derektamsen/derektamsen.github.io-hugo
+
+go 1.23.4
+
+require github.com/tomfran/typo v1.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/tomfran/typo v1.15.0 h1:lXTTzIRQDAlPLJarwrtJffXj1FRFP2IC93CTkqE65/g=
+github.com/tomfran/typo v1.15.0/go.mod h1:8xNarVYpf1wXyorV/5F4NnTzJXGi8tTtJxourpJv4MA=

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,14 +1,16 @@
 baseURL = 'https://www.devopsderek.com/'
 languageCode = 'en-us'
 title = 'devops Derek'
-theme = 'typo'
-
 copyright = 'This work is licensed under CC BY-SA 4.0'
 
 # Google analytics code
 googleAnalytics = 'G-FLLW615HYM'
 
 enableRobotsTXT = true
+
+[module]
+[[module.imports]]
+path = "github.com/tomfran/typo"
 
 [taxonomies]
   tag = 'tags'


### PR DESCRIPTION
Switch vendor of the typo theme from a git submodule to a [hugo module](https://gohugo.io/hugo-modules/use-modules/#use-a-module-for-a-theme).
This is the current way to manage hugo themes based on go modules. I
also added go to the devcontainer config to support managing hugo modules.