### PR TITLE
chore: update typo theme v2.0.1

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/debian
 {
-	"name": "Debian",
+	"name": "hugo",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/base:bookworm",
 	"features": {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,6 @@ module github.com/derektamsen/derektamsen.github.io-hugo
 
 go 1.23.4
 
-require github.com/tomfran/typo v1.16.0 // indirect
+require (
+	github.com/tomfran/typo/v2 v2.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/tomfran/typo v1.16.0 h1:g5KaoH+mK1tTCG8GsrtFl9Tbzy0jmgYCl3mMTnAmR38=
-github.com/tomfran/typo v1.16.0/go.mod h1:8xNarVYpf1wXyorV/5F4NnTzJXGi8tTtJxourpJv4MA=
+github.com/tomfran/typo/v2 v2.0.1 h1:NJDCMHrIEzCB6cgwyyEKu0AoYBWD+ke4s6i45FzdhuQ=
+github.com/tomfran/typo/v2 v2.0.1/go.mod h1:MKqFFa6fHN+oh4/JZZkq23cUtgeck3C6GzUDKf35MAU=

--- a/hugo.toml
+++ b/hugo.toml
@@ -10,7 +10,7 @@ enableRobotsTXT = true
 
 [module]
 [[module.imports]]
-path = "github.com/tomfran/typo"
+path = "github.com/tomfran/typo/v2"
 
 [taxonomies]
   tag = 'tags'
@@ -55,7 +55,10 @@ path = "github.com/tomfran/typo"
   listDateFormat = 'Jan 2, 2006'
 
   # Breadcrumbs
-  breadcrumbs = true
+  [params.breadcrumbs]
+  enabled = true
+  showCurrentPage = true
+  home = "Home"
 
   # Giscus comments
   [params.giscus]


### PR DESCRIPTION
Update the typo theme to [v2.0.1](https://github.com/tomfran/typo/releases/tag/v2.0.1). Also configure breadcrumbs for the v2
theme version.

Renamed devcontainer to `hugo`.