### PR TITLE
chore: update go to 1.26.3, add makefile, update hugo 0.162.1, and mods

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,14 +6,14 @@
 	"image": "mcr.microsoft.com/devcontainers/base:trixie",
 	"features": {
 		"ghcr.io/devcontainers/features/hugo:1": {
-			"version": "latest"
+			"version": "0.162.1"
 		},
 		"ghcr.io/devcontainers/features/github-cli:1": {
 			"installDirectlyFromGitHubRelease": true,
 			"version": "latest"
 		},
 		"ghcr.io/devcontainers/features/go:1": {
-			"version": "1.25.5"
+			"version": "1.26.3"
 		}
 	},
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: all
+all: server
+
+.PHONY: server
+server:
+	@hugo server -D
+
+.PHONY: update-deps
+update-deps:
+	@hugo mod get -u
+	@hugo mod tidy

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/derektamsen/derektamsen.github.io-hugo
 
-go 1.25.5
+go 1.26.3
 
-require github.com/tomfran/typo/v2 v2.3.0 // indirect
+require (
+	github.com/tomfran/typo/v3 v3.0.2 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/tomfran/typo/v2 v2.3.0 h1:nHKDjR9rGcufdxlnoxwsiZoTGSiHJKnG/faOFBTpIKg=
-github.com/tomfran/typo/v2 v2.3.0/go.mod h1:MKqFFa6fHN+oh4/JZZkq23cUtgeck3C6GzUDKf35MAU=
+github.com/tomfran/typo/v3 v3.0.2 h1:dNQDHe63vw7FM18Uot+jDNRq2ekS26hZOnugmsg19Mg=
+github.com/tomfran/typo/v3 v3.0.2/go.mod h1:zA+mwXpfwf4CiUO0Ik3QIHdq9cGb/wig34fMSI2O7c0=

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,5 +1,5 @@
 baseURL = 'https://www.devopsderek.com/'
-languageCode = 'en-us'
+locale = 'en-us'
 title = 'devops Derek'
 copyright = 'This work is licensed under CC BY-SA 4.0'
 
@@ -7,7 +7,7 @@ enableRobotsTXT = true
 
 [module]
 [[module.imports]]
-path = "github.com/tomfran/typo/v2"
+path = "github.com/tomfran/typo/v3"
 
 [taxonomies]
   tag = 'tags'


### PR DESCRIPTION
- Update go to 1.26.3
- Add `makefile` with server and update-deps targets
- Update hugo to 0.162.1
- Update typo to v3.0.2
- Update hugo configs to stop using deprecated options